### PR TITLE
ci: restrict some workflows to only run upstream

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    if: github.repository == 'dbsystel/oss-red-flag-checker'
     steps:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token


### PR DESCRIPTION
Adds `if: github.repository == '...'` condition to release-please workflow so they only run in the upstream repository, not in forks.