### PR TITLE
ci: remove unsupported issues permission from app token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -27,7 +27,6 @@ jobs:
           repositories: oss-red-flag-checker
           skip-token-revoke: false
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0


### PR DESCRIPTION
Removes `permission-issues: write` from the release-please app token request, as the GitHub App doesn't have this permission and it's not needed (PR comments use the pull-requests scope).