### PR TITLE
feat: add `--local` flag to use existing local clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This projects evaluates remote repositories by looking for typical red flags lik
 ## Table of contents
 
 * [Features](#features)
+* [How it works](#how-it-works)
 * [Installation](#installation)
 * [Usage](#usage)
 * [Caveats](#caveats)
@@ -64,6 +65,48 @@ Green flags:
 * The project has an acceptable contribition distribution by multiple active developers
 * The last human commit is less than 90 days old
 
+
+## How it works
+
+### Repository access
+
+For each repository, the tool needs access to both the file contents and the GitHub API. There are three modes:
+
+**Default (remote clone):** The repository is cloned into a temporary directory, used for checks, then deleted.
+
+```sh
+ossrfc -r https://github.com/owner/repo
+```
+
+**Cache:** The clone is kept in a local cache directory so subsequent runs skip re-cloning.
+
+```sh
+ossrfc -r https://github.com/owner/repo --cache
+```
+
+**Local path (`--local`):** Use an existing local clone. The repository URL is still required for GitHub API checks, but no cloning occurs. Useful when you already have the repo checked out, or want to avoid a second clone when integrating ossrfc into a larger workflow.
+
+```sh
+ossrfc -r https://github.com/owner/repo --local /path/to/local/clone
+```
+
+> [!NOTE]
+> The `--local` path should be a full (non-shallow) clone. A shallow clone will produce inaccurate contributor and commit-age statistics since git history is incomplete.
+>
+> When ossrfc clones the repository itself (default and cache modes), it uses a depth of 100 commits. This is sufficient for most activity checks but means contributor dominance and commit-age statistics only reflect the most recent 100 commits. Use `--local` with a full clone if complete history matters.
+
+### Checks and their data sources
+
+| Check | Data source | GitHub-only |
+|---|---|---|
+| CLA/DCO in files | Local clone (README, CONTRIBUTING) | No |
+| CLA/DCO in pull requests | GitHub API | Yes |
+| inbound=outbound in files | Local clone (README, CONTRIBUTING) | No |
+| LICENSE/COPYING file exists | Local clone | No |
+| Contributor dominance | GitHub API (contributor stats, bot detection) | Yes |
+| Commit age (human vs. bot) | Local clone (git history, bot detection) | No |
+
+Checks marked "GitHub-only" are skipped automatically for non-GitHub repositories.
 
 ## Installation
 

--- a/ossrfc/checker.py
+++ b/ossrfc/checker.py
@@ -82,6 +82,17 @@ parser.add_argument(
     help="Cache cloned remote repositories to speed up subsequent checks",
 )
 parser.add_argument(
+    "-l",
+    "--local",
+    default="",
+    metavar="PATH",
+    help=(
+        "Use a local repository clone instead of cloning from the remote URL. "
+        "The repository URL (-r) is still required for GitHub API checks. "
+        "Cannot be combined with --cache."
+    ),
+)
+parser.add_argument(
     "-t",
     "--token",
     default="",
@@ -150,7 +161,7 @@ def check_enabled(disabled_checks: list, check_name: str) -> bool:
     return True
 
 
-def check_repo(repo: str, gthb: Github, disable: list, cache: bool) -> RepoReport:  # noqa: C901
+def check_repo(repo: str, gthb: Github, disable: list, cache: bool, local: str = "") -> RepoReport:  # noqa: C901, PLR0912
     """Run all checks on a single repository and return a report."""
     # Initialise the report dataclass
     report = RepoReport()
@@ -160,14 +171,19 @@ def check_repo(repo: str, gthb: Github, disable: list, cache: bool) -> RepoRepor
 
     logging.info("Checking repository %s", report.url)
 
-    # Clone repo, depending on cache status
-    if cache:
+    # Use a local path directly if provided, otherwise clone
+    if local:
+        if cache:
+            logging.warning("--local and --cache are mutually exclusive; --cache is ignored")
+        report.repodir_ = local
+        logging.info("Using local repository path: %s", local)
+    elif cache:
         report.repodir_ = get_cache_dir(report.url)
+        clone_or_pull_repository(report.url, report.repodir_)
     else:
         repodir_object = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         report.repodir_ = repodir_object.name
-
-    clone_or_pull_repository(report.url, report.repodir_)
+        clone_or_pull_repository(report.url, report.repodir_)
 
     # List all first-level files of the repository and relevant extra paths
     # for CLAs
@@ -213,7 +229,7 @@ def check_repo(repo: str, gthb: Github, disable: list, cache: bool) -> RepoRepor
         old_commits(report)
 
     # Delete temporary directory for a remote repo if it shall not be cached
-    if not cache:
+    if not cache and not local:
         logging.info("Deleting temporary directory in which remote repository has been cloned to")
         repodir_object.cleanup()
 
@@ -245,7 +261,7 @@ def main() -> None:
     report_list = []
     for repo in repos:
         # Search for indicators in the repository
-        report = check_repo(repo, gthb, args.disable, args.cache)
+        report = check_repo(repo, gthb, args.disable, args.cache, args.local)
         # Analyse and evaluate the findings
         analyse_report(report, args.ignore)
         # Add full report to report list

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2023 DB Systel GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the --local flag in check_repo."""
+
+from unittest.mock import patch
+
+from github import Github
+
+from ossrfc.checker import check_repo
+
+
+def test_check_repo_local_skips_clone(fake_repository) -> None:
+    """check_repo with local= uses the given path without cloning."""
+    repo_url = "https://github.com/dbsystel/playground"
+
+    with patch("ossrfc.checker.clone_or_pull_repository") as mock_clone:
+        report = check_repo(
+            repo=repo_url,
+            gthb=Github(),
+            disable=["cla-dco-pulls", "contributions", "commit-age"],
+            cache=False,
+            local=str(fake_repository),
+        )
+
+    mock_clone.assert_not_called()
+    assert report.repodir_ == str(fake_repository)
+    # File-based checks still ran using the local path
+    assert len(report.files_) > 0


### PR DESCRIPTION
Instead of always cloning the remote repository, --local PATH lets the caller supply an existing clone. The repository URL is still required for GitHub API checks. --cache is silently ignored when --local is set.

Useful when ossrfc is part of a larger workflow that already has the repo checked out, avoiding a redundant clone.

Also documents the three repository access modes and per-check data sources in a new 'How it works' README section, including the 100-commit depth limitation of the built-in clone.
